### PR TITLE
[YITEAM-134] Int형 결과를 받도록 수정하여 코드에 따른 처리 적용

### DIFF
--- a/Buok/Network/User/InfoCheckAPIRequest.swift
+++ b/Buok/Network/User/InfoCheckAPIRequest.swift
@@ -62,7 +62,7 @@ public struct InfoCheckAPIRequest {
         }
     }
     
-    static func checkEmail(email: String, responseHandler: @escaping (Result<String, HeroAPIError>) -> Void) {
+    static func checkEmail(email: String, responseHandler: @escaping (Result<Int, HeroAPIError>) -> Void) {
         BaseAPIRequest.requestJSONResponse(requestType: InfoCheckRequestType.emailCheck(email: email))
             .catch(type: BaseAPIError.self, { error in
                 ErrorLog("ERROR가 발생하였습니다. ==> \(error)")
@@ -75,8 +75,9 @@ public struct InfoCheckAPIRequest {
                         DebugLog("Json Data : \n\(String(data: jsonData, encoding: .utf8) ?? "nil")")
                         
                         let getData = try JSONDecoder().decode(InfoCheckServerModel.self, from: jsonData)
-                        if getData.status < 300 {
-                            responseHandler(.success(getData.data ?? ""))
+                        if getData.status < 300 || getData.status == 404 {
+                            responseHandler(.success(getData.status))
+                            DebugLog(getData.data ?? "")
                         } else {
                             responseHandler(.failure(HeroAPIError(errorCode: ErrorCode(rawValue: getData.status) ?? .unknown, statusCode: getData.status, errorMessage: getData.message)))
                         }

--- a/Buok/ViewControllers/User/Login/LoginViewController.swift
+++ b/Buok/ViewControllers/User/Login/LoginViewController.swift
@@ -33,6 +33,10 @@ public class LoginViewController: HeroBaseViewController {
         TokenManager.shared.deleteAllTokenData()
         
         viewModel.isEmailExist.bind({ isExist in
+            guard let isExist = isExist else {
+                // todo - 로그인 성공도 아니고, not found도 아님
+                return
+            }
             if isExist {
                 let loginPasswordVC = LoginPasswordViewController()
                 loginPasswordVC.viewModel = self.viewModel

--- a/Buok/ViewControllers/User/UserViewModel.swift
+++ b/Buok/ViewControllers/User/UserViewModel.swift
@@ -22,7 +22,7 @@ class UserViewModel {
     
     var isLoginSuccess: Dynamic<Bool> = Dynamic(false)
     
-    var isEmailExist: Dynamic<Bool> = Dynamic(false)
+    var isEmailExist: Dynamic<Bool?> = Dynamic(false)
     var isNicknameExist: Dynamic<Bool> = Dynamic(false)
     var isSignUpSuccess: Dynamic<Bool> = Dynamic(false)
     
@@ -44,13 +44,15 @@ class UserViewModel {
         self.email = email
         InfoCheckAPIRequest.checkEmail(email: self.email, responseHandler: { result in
             switch result {
-            case .success(let resultString):
-                DebugLog("Result String : \(resultString)")
-                self.isEmailExist.value = false
-//                self.isEmailExist.value = true
+            case .success(let code):
+                if code == 404 {
+                    self.isEmailExist.value = false
+                } else {
+                    DebugLog("Result code : \(code)")
+                    self.isEmailExist.value = true
+                }
             case .failure(_):
-//                self.isEmailExist.value = false
-                self.isEmailExist.value = true
+                self.isEmailExist.value = nil
                 ErrorLog("Error")
             }
         })


### PR DESCRIPTION
UserViewModel에서 checkEmail 메서드의 결과값을 String으로 받고 있던 걸 Int로 수정해서 서버에서 받는 상태코드를 반환하도록 했습니다. 그리고 404일 때는 LoginViewController에서 회원가입화면으로 이동하도록 하였습니다.