### PR TITLE
[YITEAM-139] 버킷 추가시 end date 적용

### DIFF
--- a/Buok/CommonViews/Bucket/BucketItemCell.swift
+++ b/Buok/CommonViews/Bucket/BucketItemCell.swift
@@ -148,7 +148,7 @@ final class BucketItemCell: UICollectionViewCell {
                 if Calendar.current.dateComponents([.day], from: endDate, to: Date()).day == 0 {
                     dateLabel.text = "D - Day"
                 } else {
-                    dateLabel.text = "D - \(Calendar.current.dateComponents([.day], from: endDate, to: Date()).day ?? 0)"
+                    dateLabel.text = "D - \(Calendar.current.dateComponents([.day], from: Date(), to: endDate).day ?? 0)"
                 }
             }
         }

--- a/Buok/ViewControllers/Main/Create/CreateViewController.swift
+++ b/Buok/ViewControllers/Main/Create/CreateViewController.swift
@@ -299,7 +299,7 @@ final class CreateViewController: HeroBaseViewController, UINavigationController
         }
         
         dateChooserAlert.addAction(UIAlertAction(title: "선택완료", style: .default, handler: { _ in
-            self.viewModel.finishDate.value = self.datePicker.date
+            self.viewModel.setBucketFinishDate(date: self.datePicker.date)
         }))
     }
     

--- a/HeroCommon/HeroCommon/Date+Extension.swift
+++ b/HeroCommon/HeroCommon/Date+Extension.swift
@@ -9,32 +9,26 @@ import Foundation
 
 public extension Date {
     func convertToSmallString() -> String {
-        let date: Date = Date()
-        
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
         
-        let dateString = dateFormatter.string(from: date)
+        let dateString = dateFormatter.string(from: self)
         return dateString
     }
     
     func convertToString() -> String {
-        let date: Date = Date()
-        
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         
-        let dateString = dateFormatter.string(from: date)
+        let dateString = dateFormatter.string(from: self)
         return dateString
     }
     
     func convertToKoreanString() -> String {
-        let date: Date = Date()
-        
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy년 MM월 dd일"
         
-        let dateString = dateFormatter.string(from: date)
+        let dateString = dateFormatter.string(from: self)
         return dateString
     }
     


### PR DESCRIPTION
버킷 등록할 때 end date가 적용이 안되어서 보았더니, Date Extension 부분에서 데이터가 Date( )로 초기화되고 있어서 수정했습니다. 그리고 BucketItemCell의 date label에서 디데이가 나올 때, `D - 2312` 가 아닌 `D - -2312` 로 나오는 문제도 해결했습니다.