### PR TITLE
[YITEAM-127] 프로필 수정 업로드 오류 및 Date extension 문제 해결

### DIFF
--- a/Buok/ViewControllers/Main/Profile/EditProfile/EditProfileViewController.swift
+++ b/Buok/ViewControllers/Main/Profile/EditProfile/EditProfileViewController.swift
@@ -115,6 +115,7 @@ extension EditProfileViewController: UITextFieldDelegate, UITextViewDelegate {
             self.nicknameTextField.text = text
         }
         self.nicknameCountLabel.text = "\(text.count)/12"
+        self.viewModel.nickname.value = textField.text ?? ""
     }
     
     func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
@@ -133,6 +134,7 @@ extension EditProfileViewController: UITextFieldDelegate, UITextViewDelegate {
             let beforeEnd = textView.text.index(before: textView.text.endIndex)
             textView.text = String(textView.text[start..<beforeEnd])
         }
+        self.viewModel.introduce.value = textView.text
     }
 }
 

--- a/HeroCommon/HeroCommon/String+Extension.swift
+++ b/HeroCommon/HeroCommon/String+Extension.swift
@@ -22,7 +22,7 @@ public extension String {
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         dateFormatter.timeZone = NSTimeZone(name: "UTC") as TimeZone?
 
-        let date: Date = dateFormatter.date(from: self)!
+        let date: Date = dateFormatter.date(from: self) ?? Date()
         return date
     }
 	


### PR DESCRIPTION
프로필 수정 과정에서 nickname과 introduce 텍스트 필드 및 텍스트 뷰 내용이 ViewModel에 전달되지 않고 있어서 프로필 수정이 되지 않고 있었습니다.